### PR TITLE
Fix spelling and grammar across the library

### DIFF
--- a/hondana/artist.py
+++ b/hondana/artist.py
@@ -168,7 +168,7 @@ class Artist:
 
     @property
     def url(self) -> str:
-        """The URL to to this artist.
+        """The URL to this artist.
 
         Returns
         --------

--- a/hondana/author.py
+++ b/hondana/author.py
@@ -167,7 +167,7 @@ class Author:
 
     @property
     def url(self) -> str:
-        """The URL to to this author.
+        """The URL to this author.
 
         Returns
         --------

--- a/hondana/chapter.py
+++ b/hondana/chapter.py
@@ -189,7 +189,7 @@ class Chapter:
         Parameters
         ------------
         ssl :class:`bool`
-            Wether to obtain an @Home URL for SSL only connections.
+            Whether to obtain an @Home URL for SSL only connections.
             Defaults to ``True``.
 
         Returns
@@ -282,7 +282,7 @@ class Chapter:
 
 
         .. note::
-            The can be ``None`` if the chapter has no relationships key.
+            This can be ``None`` if the chapter has no relationships key.
             Or in the almost impossible situation that it has no ``"manga"`` relationship.
 
         Returns

--- a/hondana/client.py
+++ b/hondana/client.py
@@ -209,7 +209,7 @@ class Client:
         """
         This attribute will return a permissions instance for the current logged in user.
 
-        You must be authenticated to run this, and logged in.
+        You must be authenticated to access this, and logged in.
 
         If you wish to just check permissions without making an api request, consider :meth:`~hondana.Client.static_login`
 
@@ -315,9 +315,9 @@ class Client:
             If set lower than 0 then it is set to 0.
         translated_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to filter the returned chapters with.
-        original_languages: List[:class:`~hondana.types.LanguageCode`]
+        original_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to filter the original language of the returned chapters with.
-        excluded_original_languages: List[:class:`~hondana.types.LanguageCode`]
+        excluded_original_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to negate filter the original language of the returned chapters with.
         content_rating: Optional[List[:class:`~hondana.ContentRating`]]
             The content rating to filter the feed by.
@@ -892,9 +892,9 @@ class Client:
             Defaults to 0. The pagination offset for the request.
         translated_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to filter the returned chapters with.
-        original_languages: List[:class:`~hondana.types.LanguageCode`]
+        original_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to filter the original language of the returned chapters with.
-        excluded_original_languages: List[:class:`~hondana.types.LanguageCode`]
+        excluded_original_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to negate filter the original language of the returned chapters with.
         content_rating: Optional[List[:class:`~hondana.ContentRating`]]
             The content rating to filter the feed by.
@@ -1039,7 +1039,7 @@ class Client:
     ) -> MangaCollection:
         """|coro|
 
-        This method will get a list of all of the currently loggd in user's followed manga.
+        This method will return an object containing all the followed manga from the currently logged in user.
 
         Parameters
         -----------
@@ -1272,7 +1272,7 @@ class Client:
         ------------
         manga_id: :class:`str`
             The manga ID we are creating a relation to.
-        target_id: :class:`str`
+        target_manga: :class:`str`
             The manga ID of the related manga.
         relation_type: :class:`~hondana.MangaRelationType`
             The relation type we are creating.
@@ -1425,7 +1425,7 @@ class Client:
             A query parameter to choose how the responses are ordered.
         includes: Optional[:class:`~hondana.query.ChapterIncludes`]
             The list of options to include increased payloads for per chapter.
-            Defaults to all possible expansiions.
+            Defaults to all possible expansions.
 
 
         .. note::
@@ -1935,6 +1935,7 @@ class Client:
             A returned collection of users.
         """
         innert_limit = limit or 10
+        # Not sure if this should be `inner_limit` or something.
 
         users = []
 
@@ -2647,9 +2648,9 @@ class Client:
             Defaults to 0. The pagination offset for the request.
         translated_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to filter the returned chapters with.
-        original_languages: List[:class:`~hondana.types.LanguageCode`]
+        original_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to filter the original language of the returned chapters with.
-        excluded_original_languages: List[:class:`~hondana.types.LanguageCode`]
+        excluded_original_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to negate filter the original language of the returned chapters with.
         content_rating: Optional[List[:class:`~hondana.ContentRating`]]
             The content rating to filter this query with.
@@ -2882,7 +2883,7 @@ class Client:
             The new twitter url to update the group with.
         manga_updates: Optional[:class:`str`]
             The URL to the group's page where they post updates, if any.
-        focused_language: Optional[List[:class:`~hondana.types.LanguageCode`]]
+        focused_languages: Optional[List[:class:`~hondana.types.LanguageCode`]]
             The new list of language codes to update the group with.
         inactive: Optional[:class:`bool`]
             If the group is inactive or not.
@@ -2900,7 +2901,7 @@ class Client:
 
         .. note::
             The ``publish_delay`` parameter must match the :class:`hondana.utils.MANGADEX_TIME_REGEX` pattern
-            or be a valid ``datetime.timdelta``.
+            or be a valid ``datetime.timedelta``.
 
         Raises
         -------
@@ -3544,10 +3545,10 @@ class Client:
             The manga we will be uploading a chapter for.
         volume: :class:`str`
             The volume we are uploading a chapter for.
-            Typically this is a numerical identifier.
+            Typically, this is a numerical identifier.
         chapter: :class:`str`
             The chapter we are uploading.
-            Typically this is a numerical identifier.
+            Typically, this is a numerical identifier.
         title: :class:`str`
             The chapter's title.
         translated_language: :class:`~hondana.types.LanguageCode`
@@ -3603,10 +3604,10 @@ class Client:
             The manga we will be uploading a chapter for.
         volume: :class:`str`
             The volume we are uploading a chapter for.
-            Typically this is a numerical identifier.
+            Typically, this is a numerical identifier.
         chapter: :class:`str`
             The chapter we are uploading.
-            Typically this is a numerical identifier.
+            Typically, this is a numerical identifier.
         title: :class:`str`
             The chapter's title.
         translated_language: :class:`~hondana.types.LanguageCode`

--- a/hondana/client.py
+++ b/hondana/client.py
@@ -1934,16 +1934,15 @@ class Client:
         :class:`UserCollection`
             A returned collection of users.
         """
-        innert_limit = limit or 10
-        # Not sure if this should be `inner_limit` or something.
+        inner_limit = limit or 10
 
         users = []
 
         while True:
-            data = await self._http._user_list(limit=innert_limit, offset=offset, ids=ids, username=username, order=order)
+            data = await self._http._user_list(limit=inner_limit, offset=offset, ids=ids, username=username, order=order)
             users.extend([User(self._http, item) for item in data["data"]])
 
-            offset = offset + innert_limit
+            offset = offset + inner_limit
             if not data["data"] or offset >= 10_000 or limit is not None:
                 break
 

--- a/hondana/collections.py
+++ b/hondana/collections.py
@@ -255,7 +255,7 @@ class CoverCollection(_Collection):
         super().__init__()
 
     def __repr__(self) -> str:
-        return f"<CovverCollection covers={len(self.covers)} total={self.total} offset={self.offset} limit={self.limit}>"
+        return f"<CoverCollection covers={len(self.covers)} total={self.total} offset={self.offset} limit={self.limit}>"
 
 
 class ScanlatorGroupCollection(_Collection):

--- a/hondana/custom_list.py
+++ b/hondana/custom_list.py
@@ -90,7 +90,7 @@ class CustomList:
 
     @property
     def url(self) -> str:
-        """The URL to to this custom list.
+        """The URL to this custom list.
 
         Returns
         --------

--- a/hondana/http.py
+++ b/hondana/http.py
@@ -292,8 +292,7 @@ class HTTPClient:
         self.__refresh_token = refresh_token
         return token
 
-    @staticmethod
-    def _get_expiry(token: str) -> datetime.datetime:
+    def _get_expiry(self, token: str) -> datetime.datetime:
         payload = token.split(".")[1]
         padding = len(payload) % 4
         payload = b64decode(payload + "=" * padding)

--- a/hondana/http.py
+++ b/hondana/http.py
@@ -292,7 +292,8 @@ class HTTPClient:
         self.__refresh_token = refresh_token
         return token
 
-    def _get_expiry(self, token: str) -> datetime.datetime:
+    @staticmethod
+    def _get_expiry(token: str) -> datetime.datetime:
         payload = token.split(".")[1]
         padding = len(payload) % 4
         payload = b64decode(payload + "=" * padding)

--- a/hondana/manga.py
+++ b/hondana/manga.py
@@ -852,9 +852,9 @@ class Manga:
             Defaults to 0. The pagination offset for the request.
         translated_language: List[:class:`str`]
             A list of language codes to filter the returned chapters with.
-        original_languages: List[:class:`~hondana.types.LanguageCode`]
+        original_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to filter the original language of the returned chapters with.
-        excluded_original_languages: List[:class:`~hondana.types.LanguageCode`]
+        excluded_original_language: List[:class:`~hondana.types.LanguageCode`]
             A list of language codes to negate filter the original language of the returned chapters with.
         content_rating: Optional[List[:class:`~hondana.ContentRating`]]
             The content rating to filter the feed by.
@@ -1122,9 +1122,7 @@ class Manga:
             The scanlation group UUID(s) to limit the request with.
         uploader: Optional[:class:`str`]
             The uploader UUID to limit the request with.
-        manga: Optional[:class:`str`]
-            The manga UUID to limit the request with.
-        volume: Optional[Union[:class:`str`, List[:class:`str`]]]
+        volumes: Optional[Union[:class:`str`, List[:class:`str`]]]
             The volume UUID or UUIDs to limit the request with.
         chapter: Optional[Union[:class:`str`, List[:class:`str`]]]
             The chapter UUID or UUIDs to limit the request with.
@@ -1312,7 +1310,7 @@ class Manga:
 
         Parameters
         ------------
-        target_id: :class:`str`
+        target_manga: :class:`str`
             The manga ID of the related manga.
         relation_type: :class:`~hondana.MangaRelationType`
 

--- a/hondana/query.py
+++ b/hondana/query.py
@@ -308,7 +308,7 @@ class UserListOrderQuery(_OrderQuery):
     Parameters
     -----------
     username: :class:`~hondana.query.Order`
-        Userame ordering.
+        Username ordering.
     """
 
     __slots__ = ("username",)
@@ -397,7 +397,7 @@ class ChapterIncludes(_Includes):
         self.scanlation_group: bool = scanlation_group
 
     def to_query(self) -> list[str]:
-        """Retuns a list of valid query strings.
+        """Returns a list of valid query strings.
 
         Returns
         --------
@@ -429,7 +429,7 @@ class CoverIncludes(_Includes):
         self.user: bool = user
 
     def to_query(self) -> list[str]:
-        """Retuns a list of valid query strings.
+        """Returns a list of valid query strings.
 
         Returns
         --------
@@ -465,7 +465,7 @@ class CustomListIncludes(_Includes):
         self.owner: bool = owner
 
     def to_query(self) -> list[str]:
-        """Retuns a list of valid query strings."""
+        """Returns a list of valid query strings."""
         return super().to_query()
 
 
@@ -499,7 +499,7 @@ class MangaIncludes(_Includes):
         self.manga: bool = manga
 
     def to_query(self) -> list[str]:
-        """Retuns a list of valid query strings.
+        """Returns a list of valid query strings.
 
         Returns
         --------
@@ -531,7 +531,7 @@ class ScanlatorGroupIncludes(_Includes):
         self.member: bool = member
 
     def to_query(self) -> list[str]:
-        """Retuns a list of valid query strings.
+        """Returns a list of valid query strings.
 
         Returns
         --------

--- a/hondana/report.py
+++ b/hondana/report.py
@@ -39,7 +39,7 @@ __all__ = ("Report",)
 
 class Report:
     """
-    Parameters
+    Attributes
     -----------
     id: :class:`str`
         The UUID of this report.

--- a/hondana/scanlator_group.py
+++ b/hondana/scanlator_group.py
@@ -60,7 +60,7 @@ class ScanlatorGroup:
         The IRC channel for this scanlator group.
     discord: :class:`str`
         The Discord server for this scanlator group.
-    focused_language: Optional[List[str]]
+    focused_languages: Optional[List[str]]
         The scanlator group's focused languages, if any.
     contact_email: :class:`str`
         The contact email for this scanlator group.
@@ -350,7 +350,7 @@ class ScanlatorGroup:
             The new twitter url to update the group with.
         manga_updates: Optional[:class:`str`]
             The URL for this group's manga updates page, if any.
-        focused_language: Optional[List[:class:`~hondana.types.LanguageCode`]]
+        focused_languages: Optional[List[:class:`~hondana.types.LanguageCode`]]
             The new list of language codes to update the group with.
         inactive: Optional[:class:`bool`]
             If the group is inactive or not.


### PR DESCRIPTION
Does pretty much what the title says.

I did change some docstrings to more accurately represent the actual paramater names, not sure if you want to keep those change but we'll see. There was one place where the param name is `volume` which is typehinted as being a `str`, however the docstring claims its typehint should be `list[str]`, even more wierd is that the internal http client method that it calls has the opposite problem. I'll probably open another PR to fix stuff like this, is that okay?

Can't believe I was called 'pr boi' 😤 
Be happy i didn't use gitmoji for the commit name...

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
