### PR TITLE
Remove authentication for manga statistics

### DIFF
--- a/hondana/client.py
+++ b/hondana/client.py
@@ -3600,7 +3600,6 @@ class Client:
         key = next(iter(data["statistics"]))
         return MangaStatistics(self._http, key, data["statistics"][key])
 
-    @require_authentication
     async def find_manga_statistics(self, manga_ids: list[str], /) -> list[MangaStatistics]:
         """|coro|
 


### PR DESCRIPTION
## Summary

It removes the authentication requirement for manga statistics. The API docs are wrong, and no authorization is needed.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
