### PR TITLE
Fix scanlator group bugs

### DIFF
--- a/hondana/chapter.py
+++ b/hondana/chapter.py
@@ -344,7 +344,6 @@ class Chapter:
         for relationship in self._relationships:
             if relationship["type"] == "scanlation_group":
                 resolved.append(relationship)
-                break
 
         fmt = []
         for payload in resolved:
@@ -436,7 +435,7 @@ class Chapter:
 
         resolved: list[ScanlationGroupResponse] = []
         for relationship in self._relationships:
-            if relationship["type"] == "group":
+            if relationship["type"] == "scanlation_group":
                 resolved.append(relationship)
 
         if not resolved:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Bug #1: If there are multiple scanlation groups the library would only return the first one.
Bug #2: `get_scanlator_group()` does not work because of an invalid relationship name.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
