### PR TITLE
Add new required boolean in ChapterUpload for accepting the terms of service.

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -30,3 +30,23 @@ Unauthorized
 Forbidden
 ---------
 .. autoexception:: Forbidden()
+
+MangaDexServerError
+-------------------
+.. autoexception:: MangaDexServerError()
+
+PreviousAPIVersionRequest
+-------------------------
+.. autoexception:: PreviousAPIVersionRequest()
+
+RefreshTokenFailure
+-------------------
+.. autoexception:: RefreshTokenFailure()
+
+TermsOfServiceNotAccepted
+-------------------------
+.. autoexception:: TermsOfServiceNotAccepted()
+
+UploadInProgress
+----------------
+.. autoexception:: UploadInProgress()

--- a/examples/upload_a_chapter.py
+++ b/examples/upload_a_chapter.py
@@ -32,6 +32,8 @@ async def main() -> None:
             title=title,
             translated_language=translated_language,
             scanlator_groups=scanlator_groups,
+            # we need to accept the terms of service to upload a chapter.
+            accept_tos=True,
         ) as upload_session:
             # let's open up some files and use their paths...
             files = [*pathlib.Path("./to_upload").iterdir()]
@@ -74,6 +76,7 @@ async def alternative_main() -> None:
             title=title,
             translated_language=translated_language,
             scanlator_groups=scanlator_groups,
+            accept_tos=True,
         )
 
         # I recommend the context manager method, since the session checking and committing are done for you.
@@ -115,6 +118,7 @@ async def other_alternative_main() -> None:
             translated_language=translated_language,
             images=files,
             scanlator_groups=scanlator_groups,
+            accept_tos=True,
         )
 
 

--- a/hondana/client.py
+++ b/hondana/client.py
@@ -3796,6 +3796,7 @@ class Client:
         publish_at: datetime.datetime | None = None,
         existing_upload_session_id: str | None = None,
         version: int | None = None,
+        accept_tos: bool,
     ) -> ChapterUpload:
         """
         This method will return an async `context manager <https://realpython.com/python-with-statement/>`_
@@ -3812,7 +3813,8 @@ class Client:
                 volume=volume,
                 title=title,
                 translated_language=translated_language,
-                scanlator_groups=scanlator_groups
+                scanlator_groups=scanlator_groups,
+                accept_tos=True,
             ) as session:
                 await session.upload_images(your_list_of_bytes)
 
@@ -3850,6 +3852,8 @@ class Client:
         version: Optional[:class:`int`]
             The new version of the chapter you are editing.
             Only necessary if ``chapter_to_edit`` is not ``None``.
+        accept_tos: :class:`bool`
+            Whether you accept the `MangaDex Terms of Service <https://mangadex.org/compliance>`_ by uploading this chapter.
 
 
         .. note::
@@ -3872,6 +3876,7 @@ class Client:
             publish_at=publish_at,
             existing_upload_session_id=existing_upload_session_id,
             version=version,
+            accept_tos=accept_tos,
         )
 
     @require_authentication
@@ -3890,6 +3895,7 @@ class Client:
         publish_at: datetime.datetime | None = None,
         existing_upload_session_id: str | None = None,
         version: int | None = None,
+        accept_tos: bool,
         images: list[pathlib.Path],
     ) -> Chapter:
         """|coro|
@@ -3929,6 +3935,8 @@ class Client:
         version: Optional[:class:`int`]
             The new version of the chapter you are editing.
             Only necessary if ``chapter_to_edit`` is not ``None``.
+        accept_tos: :class:`bool`
+            Whether you accept the `MangaDex Terms of Service <https://mangadex.org/compliance>`_ by uploading this chapter.
         images: List[:class:`pathlib.Path`]
             The list of images to upload as their Paths.
 
@@ -3968,6 +3976,7 @@ class Client:
             scanlator_groups=scanlator_groups,
             external_url=external_url,
             existing_upload_session_id=existing_upload_session_id,
+            accept_tos=accept_tos,
             version=version,
         ) as session:
             await session.upload_images(images)

--- a/hondana/errors.py
+++ b/hondana/errors.py
@@ -40,6 +40,7 @@ __all__ = (
     "NotFound",
     "PreviousAPIVersionRequest",
     "RefreshTokenFailure",
+    "TermsOfServiceNotAccepted",
     "Unauthorized",
     "UploadInProgress",
 )
@@ -314,3 +315,7 @@ class NotFound(APIException):
 
     def __init__(self, response: aiohttp.ClientResponse, /, *, errors: list[ErrorType]) -> None:
         super().__init__(response, status_code=404, errors=errors)
+
+
+class TermsOfServiceNotAccepted(Exception):
+    """An error for when the ToS is not accepted prior to a chapter upload."""


### PR DESCRIPTION
## Summary

This PR adds a new `accept_tos=` boolean to the ChapterUpload constructor for the end users to accept [MangaDex's Terms of Service]() by uploading their chapter(s).
This also adds all required documentation and updates the relevant examples.

This PR will remain in draft until the flag hits the live API.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes a submitted GitHub issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
