### PR TITLE
Remove incorrect `requires_auth` decorator from method

### DIFF
--- a/hondana/client.py
+++ b/hondana/client.py
@@ -2812,7 +2812,6 @@ class Client:
 
         return CustomListCollection(self._http, data, lists)
 
-    @require_authentication
     async def get_users_custom_lists(
         self,
         user_id: str,

--- a/hondana/client.py
+++ b/hondana/client.py
@@ -2837,16 +2837,11 @@ class Client:
         .. note::
             Passing ``None`` to ``limit`` will attempt to retrieve all items in the chapter feed.
 
-        Raises
-        ------
-        Forbidden
-            The request returned an error due to authentication failure.
-
         Returns
         -------
         :class:`~hondana.CustomListCollection`
             A returned collection of custom lists.
-        """  # noqa: DOC502 # raised in method call
+        """
         inner_limit = limit or 10
 
         lists: list[CustomList] = []


### PR DESCRIPTION
Fixes #53

## Summary

This PR removes an accidentally placed `requires_auth` decorator over a method which does not require authentication.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes a submitted GitHub issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
